### PR TITLE
Add a default initializing view with a helpful getting started message

### DIFF
--- a/src/components/Initializing.js
+++ b/src/components/Initializing.js
@@ -1,0 +1,38 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import * as actions from '../actions';
+
+class Initializing extends Component {
+  render() {
+    const {
+      className, profilerUrl,
+    } = this.props;
+
+    return (
+      <div className={className}>
+        <div className={`${className}-text`}>
+          <h1>Waiting on Gecko Profiler to provide a profile.</h1>
+          <p>
+            Make sure Firefox is running the <a href={profilerUrl}> new version of the
+            gecko profiler addon</a>. You can control the profiler with the following two
+            shortcuts.
+          </p>
+          <ul>
+            <li><span>Ctrl</span>+<span>Shift</span>+<span>5</span>: Stop / Restart profiling</li>
+            <li><span>Ctrl</span>+<span>Shift</span>+<span>6</span>: Capture the profile and open up this interface.</li>
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+Initializing.propTypes = {
+  className: PropTypes.string.isRequired,
+  profilerUrl: PropTypes.string.isRequired,
+};
+
+export default connect(() => ({
+  className: 'initializing',
+  profilerUrl: 'https://github.com/mstange/Gecko-Profiler-Addon/tree/for-cleopatra-react',
+}), actions)(Initializing);

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -5,6 +5,7 @@ import { symbolicateProfile } from '../symbolication';
 import { SymbolStore } from '../symbol-store';
 import * as Actions from '../actions';
 import ProfileViewer from '../components/ProfileViewer';
+import Initializing from '../components/Initializing';
 
 class App extends Component {
   constructor(props) {
@@ -50,12 +51,21 @@ class App extends Component {
 
   render() {
     const { view, params, location } = this.props;
-    if (view !== 'PROFILE') {
-      return (<div></div>);
+
+    switch (view) {
+      case 'INITIALIZING':
+        return (
+          <Initializing />
+        );
+      case 'PROFILE':
+        return (
+          <ProfileViewer params={params} location={location}/>
+        );
+      default:
+        return (
+          <div>View not found.</div>
+        );
     }
-    return (
-      <ProfileViewer params={params} location={location}/>
-    );
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -633,3 +633,41 @@ body, #root, .profileViewer {
   -moz-user-select: none;
   user-select: none;
 }
+
+.initializing {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height:1.5;
+}
+
+.initializing-text {
+  max-width: 50%;
+  border: 1px solid #CCC;
+  padding: 3em;
+  font-size: 130%;
+}
+
+.initializing-text h1 {
+  margin-top: 0;
+  margin-bottom: 0.5em;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid #DDD;
+}
+
+.initializing-text span {
+  background-color: #F6F6F6;
+  border: 1px solid #CCC;
+  border-radius: 0.2em;
+  display:inline-block;
+  padding: 0.0em 0.5em;
+  box-shadow: 0.1em 0.1em 0 #BBB;
+  margin: 0 0.2em;
+}
+
+.initializing-text li {
+  margin: 1em 0;
+}


### PR DESCRIPTION
I wanted to add something besides a blank screen when you load up the tool so that you know it's actually there and working. Loading the tool for the first time was pretty confusing, so I thought this might help a little. The initializing component could be restyled and fit into the UI a bit better once there are sidebars, tabs and the like later on.